### PR TITLE
Add `Matrix::rank()` method to `@mutable`

### DIFF
--- a/src/mutable/matrix.mbt
+++ b/src/mutable/matrix.mbt
@@ -1536,7 +1536,7 @@ pub fn[T] to_vector(self : Matrix[T]) -> Vector[T] {
 /// let rank = m.rank()
 /// inspect(rank, content="2")  // The rank of the matrix is 2
 /// ```
-pub fn[T : Compare + Num + Inverse + Sub] rank(self : Matrix[T]) -> Int {
+pub fn[T : Compare + Num + Inverse + Sub] Matrix::rank(self : Matrix[T]) -> Int {
   let m = self.copy()
   let _ = m.reduce_row_elimination()
   let mut rank = 0

--- a/src/mutable/matrix.mbt
+++ b/src/mutable/matrix.mbt
@@ -1518,3 +1518,60 @@ pub fn[T] col_to_vector(self : Matrix[T], col : Int) -> Vector[T] {
 pub fn[T] to_vector(self : Matrix[T]) -> Vector[T] {
   self.data.copy()
 }
+
+///|
+/// Calculates the rank of the matrix using row reduction.
+/// 
+/// Parameters:
+/// 
+/// * `self` : The matrix to get the rank of.
+///
+/// Returns the rank of the matrix, which is the dimension of the vector space
+/// spanned by its rows or columns.
+/// 
+/// Example:
+/// 
+/// ```moonbit
+/// let m = @mutable.Matrix::from_2d_array([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [7.0, 8.0, 9.0]])
+/// let rank = m.rank()
+/// inspect(rank, content="2")  // The rank of the matrix is 2
+/// ```
+pub fn[T : Compare + Num + Inverse + Sub] rank(self : Matrix[T]) -> Int {
+  let m = self.copy()
+  let _ = m.reduce_row_elimination()
+  let mut rank = 0
+  for i in 0..<m.row {
+    let mut has_nonzero = false
+    for j in 0..<m.col {
+      if m[i][j] != T::zero() {
+        has_nonzero = true
+        break
+      }
+    }
+    if has_nonzero {
+      rank += 1
+    }
+  }
+  rank
+}
+
+///|
+/// Tests the rank calculation of a matrix.
+test "rank of matrix" {
+  let m1 = Matrix::from_2d_array([[1.0, 2.0], [3.0, 4.0]])
+  let m2 = Matrix::from_2d_array([[1.0, 2.0], [2.0, 4.0]])
+  let m3 = Matrix::from_2d_array([[0.0, 0.0], [0.0, 0.0]])
+  let m4 = Matrix::from_2d_array([
+    [1.0, 2.0, 3.0],
+    [4.0, 5.0, 6.0],
+    [7.0, 8.0, 9.0],
+  ])
+  let r1 = m1.rank()
+  let r2 = m2.rank()
+  let r3 = m3.rank()
+  let r4 = m4.rank()
+  inspect(r1, content="2")
+  inspect(r2, content="1")
+  inspect(r3, content="0")
+  inspect(r4, content="2")
+}

--- a/src/mutable/mutable.mbti
+++ b/src/mutable/mutable.mbti
@@ -41,6 +41,7 @@ fn[T] Matrix::new(Int, Int, T) -> Self[T]
 fn[T : Compare + @luna-generic.Zero] Matrix::null(Self[T]) -> Bool
 fn[T] Matrix::op_get(Self[T], Int) -> Lens[T]
 fn[T : @luna-generic.Semiring] Matrix::pow(Self[T], Int) -> Self[T]
+fn[T : Compare + @luna-generic.Num + @luna-generic.Inverse + Sub] Matrix::rank(Self[T]) -> Int
 fn[T : Compare + @luna-generic.Num + Sub + @luna-generic.Inverse] Matrix::reduce_row_elimination(Self[T]) -> Self[T]
 fn[T] Matrix::row(Self[T]) -> Int
 fn[T] Matrix::row_to_array(Self[T], Int) -> Array[T]


### PR DESCRIPTION
## Summary
- This PR add a new method `Matrix::rank()` to calculates the rank of the matrix using row reduction.

## New methed
- `rank()`: Calculates the rank of the matrix using row reduction.

### Example:
```moonbit
let m = @mutable.Matrix::from_2d_array([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [7.0, 8.0, 9.0]])
let rank = m.rank()
inspect(rank, content="2")  // The rank of the matrix is 2
```