### PR TITLE
Add `trace()` method for `@mutable.Matrix`

### DIFF
--- a/src/internal/internal.mbti
+++ b/src/internal/internal.mbti
@@ -1,0 +1,16 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "Luna-Flow/linear-algebra/internal"
+
+// Values
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+pub trait HomomorphismNat {
+  from_nat(Int) -> Self
+}
+impl HomomorphismNat for Float
+impl HomomorphismNat for Double
+

--- a/src/mutable/matrix.mbt
+++ b/src/mutable/matrix.mbt
@@ -1602,3 +1602,97 @@ test "rank of matrix" {
   inspect(r3, content="0")
   inspect(r4, content="2")
 }
+
+///|
+/// Calculates the trace of a square matrix.
+/// 
+/// The trace is the sum of all diagonal elements of the matrix.
+/// This function only works on square matrices (where row count equals column count).
+/// 
+/// Parameters:
+/// 
+/// * `self` : The square matrix to calculate the trace of.
+///
+/// Returns the sum of all diagonal elements.
+/// 
+/// Panics if the matrix is not square (row count != column count).
+/// 
+/// Example:
+/// 
+/// ```moonbit
+/// let m = @mutable.Matrix::from_2d_array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+/// let trace = m.trace()
+/// inspect(trace, content="15")  // 1 + 5 + 9 = 15
+/// ```
+pub fn[T : Add + Zero] trace(self : Matrix[T]) -> T {
+  guard self.is_square() else {
+    abort("Matrix must be square to calculate trace")
+  }
+  let mut sum = T::zero()
+  for i in 0..<self.row {
+    sum = sum + self[i][i]
+  }
+  sum
+}
+
+///|
+/// Tests the trace calculation of matrices.
+test "trace of matrix" {
+  // Test 2x2 matrix
+  let m1 = Matrix::from_2d_array([[1, 2], [3, 4]])
+  let trace1 = m1.trace()
+  inspect(trace1, content="5") // 1 + 4 = 5
+
+  // Test 3x3 matrix
+  let m2 = Matrix::from_2d_array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+  let trace2 = m2.trace()
+  inspect(trace2, content="15") // 1 + 5 + 9 = 15
+
+  // Test identity matrix
+  let id : Matrix[Int] = identity(3)
+  let trace_id = id.trace()
+  inspect(trace_id, content="3") // 1 + 1 + 1 = 3
+
+  // Test zero matrix
+  let zero = Matrix::new(2, 2, 0)
+  let trace_zero = zero.trace()
+  inspect(trace_zero, content="0") // 0 + 0 = 0
+
+  // Test with floating point numbers
+  let m3 = Matrix::from_2d_array([[1.5, 2.0], [3.0, 4.5]])
+  let trace3 = m3.trace()
+  inspect(trace3, content="6") // 1.5 + 4.5 = 6.0
+}
+
+///|
+/// Tests trace calculation with different numeric types.
+test "trace with different types" {
+  // Test with Float type
+  let m_float : Matrix[Float] = Matrix::from_2d_array([[1, 2], [3, 4]]).from_nat_matrix()
+  let trace_float = m_float.trace()
+  inspect(trace_float, content="5")
+
+  // Test with Double type  
+  let m_double : Matrix[Double] = Matrix::from_2d_array([[2, 1], [1, 3]]).from_nat_matrix()
+  let trace_double = m_double.trace()
+  inspect(trace_double, content="5")
+}
+
+///|
+/// Checks if the matrix is square (i.e., has the same number of rows and columns).
+/// 
+/// Parameters:
+/// * `self` : The matrix to check for squareness.
+/// 
+/// Returns `true` if the matrix is square, `false` otherwise.
+/// 
+/// Example:
+/// ```moonbit
+/// let m1 = @mutable.Matrix::from_2d_array([[1, 2], [3, 4]])
+/// let m2 = @mutable.Matrix::from_2d_array([[1, 2, 3], [4, 5, 6]])
+/// inspect(m1.is_square(), content="true")  // 2x2 matrix is
+/// inspect(m2.is_square(), content="false") // 2x3 matrix is not square
+/// ```
+pub fn[T] Matrix::is_square(self : Matrix[T]) -> Bool {
+  self.row == self.col
+}

--- a/src/mutable/mutable.mbti
+++ b/src/mutable/mutable.mbti
@@ -2,6 +2,7 @@
 package "Luna-Flow/linear-algebra/mutable"
 
 import(
+  "Luna-Flow/linear-algebra/internal"
   "Luna-Flow/luna-generic"
 )
 
@@ -31,7 +32,9 @@ fn[T] Matrix::eachi_col(Self[T], Int, (Int, T) -> Unit) -> Unit
 fn[T] Matrix::eachi_row(Self[T], Int, (Int, T) -> Unit) -> Unit
 fn[T] Matrix::from_2d_array(Array[Array[T]]) -> Self[T]
 fn[T] Matrix::from_array(Int, Int, Array[T]) -> Self[T]
+fn[T : @internal.HomomorphismNat] Matrix::from_nat_matrix(Self[Int]) -> Self[T]
 fn[T] Matrix::horizontal_combine(Self[T], Self[T]) -> Self[T]
+fn[T] Matrix::is_square(Self[T]) -> Bool
 fn[A] Matrix::make(Int, Int, (Int, Int) -> A) -> Self[A]
 fn[T, U] Matrix::map(Self[T], (T) -> U) -> Self[U]
 fn[T] Matrix::map_col_inplace(Self[T], Int, (T) -> T) -> Unit
@@ -53,6 +56,7 @@ fn[T] Matrix::to_2d_array(Self[T]) -> Array[Array[T]]
 fn[T] Matrix::to_array(Self[T]) -> Array[T]
 fn[T] Matrix::to_transpose(Self[T]) -> Transpose[T]
 fn[T] Matrix::to_vector(Self[T]) -> Vector[T]
+fn[T : Add + @luna-generic.Zero] Matrix::trace(Self[T]) -> T
 fn[T] Matrix::transpose(Self[T]) -> Self[T]
 fn[T] Matrix::vertical_combine(Self[T], Self[T]) -> Self[T]
 impl[T : Add] Add for Matrix[T]


### PR DESCRIPTION
## Summary
- This PR add a new method `trace()` for `@matable.Matrix`, calculating the trace of a square matrix. And add a support function `is_square` to check if the matrix is square.

## New methods
- `trace` : Calculates the trace of a square matrix. The `trace` is the sum of all diagonal elements of the matrix. This function only works on square matrices.
- `is_square` : Check if the matrix is square(where row count equals column count).